### PR TITLE
v0.4.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Encoding: UTF-8
 URL: https://github.com/nicholascarey/respfun
 BugReports: https://github.com/nicholascarey/respfun/issues
 LazyData: true
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 Imports:
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: respfun
 Type: Package
 Title: Collection of random functions for use with respirometry data
 Date: 2019-03-07
-Version: 0.4.0
+Version: 0.4.1
 Author: Nicholas Carey
 Maintainer: Nicholas Carey <nicholascarey@gmail.com>
 Description: Collection of random functions for use with respirometry data. More will be added in due course. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# respfun v0.4.1
+# respfun 0.4.1
 
 This patch fixes a major issue in `eff_vol`. All previous versions of this function returned incorrect results at anything other than neutral buoyancy (multiplication instead of division in the mass & density to volume equation, doh!).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,7 @@
+# respfun v0.4.1
+
+This patch fixes a major issue in `eff_vol`. All previous versions of this function returned incorrect results at anything other than neutral buoyancy (multiplication instead of division in the mass & density to volume equation, doh!).
+
+- MAJOR FIX: fix for incorrect results returned by `eff_vol`. If you have used this function previously, please review your code and results. 
+- FIX:`spec_density` : warning when wet_mass and buoy_mass are equal (leads to infinite density calculation)
+

--- a/R/eff_vol.R
+++ b/R/eff_vol.R
@@ -95,12 +95,11 @@ eff_vol <- function(resp_vol = NULL,
     if(is.null(spec_density))
       spec_density <- marelac::sw_dens(t = t, S = S, P = P)
 
-    effect_vol <- resp_vol - (spec_mass * (spec_density/1000))
+    effect_vol <- resp_vol - (spec_mass / (spec_density/1000) # kg/m^3 to kg/L
+                              )
     }
 
   ## return
   return(effect_vol)
 
   }
-
-

--- a/R/spec_density.R
+++ b/R/spec_density.R
@@ -1,13 +1,16 @@
 #' @title Calculate specimen density
 #'
 #' @description Given a wet mass (`wet_mass`) and buoyant mass (`buoy_mass`),
-#'   this function calculates the density of the specimen. For species such as
-#'   molluscs this can be used to determine the ratio of shell to tissue mass.
-#'   It can also be used to calculate specimen volume for correcting the water
-#'   volume of a respirometer (see \code{\link{eff_vol}}). The temperature
-#'   (\code{t}) and salinity (\code{S}) at which the buoyant mass was determined
-#'   are required (as is atmospheric pressure (`P`) which defaults to 1.013253
-#'   bar, if not otherwise specified).
+#'   this function calculates the density of a specimen. Bouyant mass is the
+#'   downward force exerted while the specimen is in water, typically measured
+#'   by having a measuring plate within a tank of water suspended from a
+#'   balance above the tank.  For species such as molluscs this can be used to
+#'   determine the ratio of shell to tissue mass. It can also be used to
+#'   calculate a specimen volume for correcting the water volume of a
+#'   respirometer (see \code{\link{eff_vol}}). The temperature (`t`) and
+#'   salinity (`S`) at which the buoyant mass was determined are required (as is
+#'   atmospheric pressure (`P`) which defaults to 1.013253 bar, if not otherwise
+#'   specified).
 #'
 #' @section Inputs: Inputs must be in SI units:
 #'
@@ -56,6 +59,8 @@ spec_density <- function(wet_mass = NULL,
     stop("wet_mass is required")
   if (is.null(buoy_mass))
     stop("buoy_mass is required")
+  if (wet_mass == buoy_mass)
+    stop("Equal values of wet_mass and buoy_mass lead to infinite density errors!")
   if (is.null(t))
     stop("Temperature is required")
   if (is.null(S))

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,4 +2,5 @@ CHANGELOG
 
 v0.4.1
 
-- Fix for incorrect results returned by `eff_vol`
+- MAJOR FIX: incorrect results returned by `eff_vol`
+- FIX:`spec_density` : warning when wet_mass and buoy_mass are equal (leads to infinite density calculation)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,5 @@
 CHANGELOG
+
+v0.4.1
+
+- Fix for incorrect results returned by `eff_vol`

--- a/man/spec_density.Rd
+++ b/man/spec_density.Rd
@@ -21,13 +21,16 @@ determined. Defaults to 1.013253.}
 }
 \description{
 Given a wet mass (\code{wet_mass}) and buoyant mass (\code{buoy_mass}),
-this function calculates the density of the specimen. For species such as
-molluscs this can be used to determine the ratio of shell to tissue mass.
-It can also be used to calculate specimen volume for correcting the water
-volume of a respirometer (see \code{\link{eff_vol}}). The temperature
-(\code{t}) and salinity (\code{S}) at which the buoyant mass was determined
-are required (as is atmospheric pressure (\code{P}) which defaults to 1.013253
-bar, if not otherwise specified).
+this function calculates the density of a specimen. Bouyant mass is the
+downward force exerted while the specimen is in water, typically measured
+by having a measuring plate within a tank of water suspended from a
+balance above the tank.  For species such as molluscs this can be used to
+determine the ratio of shell to tissue mass. It can also be used to
+calculate a specimen volume for correcting the water volume of a
+respirometer (see \code{\link{eff_vol}}). The temperature (\code{t}) and
+salinity (\code{S}) at which the buoyant mass was determined are required (as is
+atmospheric pressure (\code{P}) which defaults to 1.013253 bar, if not otherwise
+specified).
 }
 \section{Inputs}{
  Inputs must be in SI units:

--- a/tests/testthat/test-eff_vol.R
+++ b/tests/testthat/test-eff_vol.R
@@ -1,17 +1,12 @@
 # library(testthat)
 
-
-output <- eff_vol(resp_vol = 0.25,
+output <- eff_vol(resp_vol = 1,
                   spec_vol = NULL,
-                  spec_mass = 0.00186,
-                  spec_density = 1000,
+                  spec_mass = 0.1,
+                  spec_density = 1000.714,
                   t = NULL,
                   S = NULL,
                   P = 1.013253)
-
-# test output value
-expect_equal(as.numeric(output),
-              0.24814)
 
 # test class
 expect_is(output,
@@ -20,26 +15,65 @@ expect_is(output,
 
 # test messages
 expect_error(eff_vol(NULL, 1, 1, 1, 1, 1, 1),
-               "Enter a respirometer volume - resp_vol")
+             "Enter a respirometer volume - resp_vol")
 expect_error(eff_vol(1, NULL, NULL, 1, 1, 1, 1))
 expect_error(eff_vol(1, 1, 1, 1, 1, 1, 1),
              "Only one of spec_mass or spec_vol should be entered.")
 expect_message(eff_vol(1, NULL, 1, 1, 1, 1, 1),
-             "NOTE: spec_density used for calculations. t and S inputs IGNORED.")
+               "NOTE: spec_density used for calculations. t and S inputs IGNORED.")
 expect_error(eff_vol(1, NULL, 1, NULL, NULL, 1, 1),
              "A spec_mass input requires either a density, or t and S inputs with which to calculate water density.")
 expect_message(eff_vol(1, 1, NULL, 1, 1, 1, 1),
                "Calculating Effective Volume as resp_vol minus spec_vol. \n All other inputs IGNORED. ")
 
-# test density calc
-output <- eff_vol(resp_vol = 0.25,
+# test density calcs
+## 10% volume at neutral buoyancy should = 0.9 vol at this t and S
+
+dens <- spec_density(wet_mass = 0.1,
+                     buoy_mass = 0,
+                     t = 1,
+                     S = 1,
+                     P = 1.013253)
+
+output <- eff_vol(resp_vol = 1,
                   spec_vol = NULL,
                   spec_mass = 0.1,
-                  spec_density = NULL,
-                  t = 1,
-                  S = 1,
-                  P = 1.013253)
+                  spec_density = dens) # density of sw at these t,S,P
 
-expect_equal(round(as.numeric(output),6),
-             0.149929)
+expect_equal(round(as.numeric(output),3),
+             0.9)
+
+## Same at 50% neutral buoyancy should = 0.95 vol at this t and S
+
+dens <- spec_density(wet_mass = 0.1,
+                     buoy_mass = 0.05,
+                     t = 1,
+                     S = 1,
+                     P = 1.013253)
+
+output <- eff_vol(resp_vol = 1,
+                  spec_vol = NULL,
+                  spec_mass = 0.1,
+                  spec_density = dens)
+
+expect_equal(round(as.numeric(output),3),
+             0.95)
+
+
+## Same at nearly 100% not buoyant should = approx x1 vol at this t and S
+
+dens <- spec_density(wet_mass = 0.1,
+                     buoy_mass = 0.099,
+                     t = 1,
+                     S = 1,
+                     P = 1.013253)
+
+output <- eff_vol(resp_vol = 1,
+                  spec_vol = NULL,
+                  spec_mass = 0.1,
+                  spec_density = dens)
+
+expect_equal(round(as.numeric(output),3),
+             0.999)
+
 

--- a/tests/testthat/test-spec_density.R
+++ b/tests/testthat/test-spec_density.R
@@ -20,13 +20,15 @@ expect_error(spec_density(NULL, 1, 0, 1, 1),
              "wet_mass is required")
 expect_error(spec_density(1, NULL, 0, 1, 1),
              "buoy_mass is required")
-expect_error(spec_density(1, 1, NULL, 1, 1),
+expect_error(spec_density(1, 0.5, NULL, 1, 1),
              "Temperature is required")
-expect_error(spec_density(1, 1, 1, NULL, 1),
+expect_error(spec_density(1, 1, 1, 1, 1),
+             "Equal values of wet_mass and buoy_mass lead to infinite density errors!")
+expect_error(spec_density(1, 0.5, 1, NULL, 1),
              "Salinity is required")
-expect_error(spec_density(1, 1, 1, 1, NULL),
+expect_error(spec_density(1, 0.5, 1, 1, NULL),
              "Atm. Pressure is required")
-expect_message(spec_density(1, 1, 1, 1, 1),
+expect_message(spec_density(1, 0.5, 1, 1, 1),
              "NOTE: Non-default P value being used")
 
 


### PR DESCRIPTION
v0.4.1

- MAJOR FIX: incorrect results returned by `eff_vol`
- FIX:`spec_density` : warning when wet_mass and buoy_mass are equal (leads to infinite density calculation)
