### PR TITLE
v0.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: respfun
 Type: Package
 Title: Collection of random functions for use with respirometry data
 Date: 2019-03-07
-Version: 0.4.1
+Version: 0.4.2
 Author: Nicholas Carey
 Maintainer: Nicholas Carey <nicholascarey@gmail.com>
 Description: Collection of random functions for use with respirometry data. More will be added in due course. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Roxygen: list(markdown = TRUE)
 Imports:
     glue,
     marelac,
-    respirometry
+    respirometry,
+    methods
 Suggests: 
     testthat,
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # respfun 0.4.2
+Another minor fix to `scale_rate`. 
+
+- The `scale_rate` function now properly extracts all rates from `respR::convert_rate` objects, not just the first one. 
 
 # respfun 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# respfun 0.4.2
+
 # respfun 0.4.1
 
 This patch fixes a major issue in `eff_vol`. All previous versions of this function returned incorrect results at anything other than neutral buoyancy (multiplication instead of division in the mass & density to volume equation, doh!).

--- a/R/scale_rate.R
+++ b/R/scale_rate.R
@@ -86,12 +86,22 @@
 scale_rate <- function(rate = NULL, mass = NULL, new.mass = NULL, b = NULL) {
 
   if(class(rate) == "convert_rate"){
-    rate <- rate$output[1]
+    rate <- rate$output
     message("--- respR::convert_rate object detected ---\n")}
 
-  if(length(c(rate, mass, new.mass, b)) != 4) stop("All four inputs are required.")
+  #if(length(c(rate, mass, new.mass, b)) != 4) stop("All four inputs are required.")
+  if(!any(c(methods::hasArg(rate),
+            methods::hasArg(mass),
+            methods::hasArg(new.mass),
+            methods::hasArg(b))))
+    stop("All four inputs are required.")
 
   new.rate <- ((new.mass / mass) ^ b) * rate
 
   return(new.rate)
 }
+
+rate = 1
+mass = 2
+new.mass = 3
+b = 0.75


### PR DESCRIPTION
Another minor fix to `scale_rate`. 

- The `scale_rate` function now properly extracts all rates from `respR::convert_rate` objects, not just the first one. 