### PR TITLE
v0.4.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: respfun
 Type: Package
 Title: Collection of useful functions for respirometry data and experiments.
 Date: 2019-03-07
-Version: 0.4.2
+Version: 0.4.3
 Author: Nicholas Carey
 Maintainer: Nicholas Carey <nicholascarey@gmail.com>
 Description: CCollection of useful functions for respirometry data and experiments. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,11 @@
 Package: respfun
 Type: Package
-Title: Collection of random functions for use with respirometry data
+Title: Collection of useful functions for respirometry data and experiments.
 Date: 2019-03-07
 Version: 0.4.2
 Author: Nicholas Carey
 Maintainer: Nicholas Carey <nicholascarey@gmail.com>
-Description: Collection of random functions for use with respirometry data. More will be added in due course. 
-    Not intended to be a fully featured package.
+Description: CCollection of useful functions for respirometry data and experiments. 
 License: GPL-3
 Encoding: UTF-8
 URL: https://github.com/nicholascarey/respfun

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# respfun 0.4.3
+
 # respfun 0.4.2
 Another minor fix to `scale_rate`. 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # respfun 0.4.3
+Minor update
+
+- `split_rate` now accepts multiple input rates, including from `convert_rate` objects. These should obviously all be rates from the *same group*. Minor change to output object as a result: `$indiv.rates` is now a `list` object with each element a vector of individual rates for teh associated group rate in `tR`. Extract via ``$indiv.rates[[1]]` etc.
 
 # respfun 0.4.2
 Another minor fix to `scale_rate`. 

--- a/R/internal_fns.R
+++ b/R/internal_fns.R
@@ -7,37 +7,35 @@
 #' @importFrom glue glue
 #' @importFrom utils head
 print.split_rate <- function(x, ...) {
-
   rates <- x$indiv.rates
   masses <- x$masses
   cat("\n# split_rate # -------------------------\n")
   cat("Rate Division Complete: \n")
-
   if(x$input == "convert_rate"){
     cat("--- respR::convert_rate object detected ---\n")
+    cat("\n")
+    cat("Total Group Rate(s) ($tR, entered via convert_rate input):\n")
+    print(x$tR)
   }
-  cat("\n")
-
-  cat(glue("Intercept (a, calculated) :               ",
-                 {x$a}))
-  cat("\n")
-  cat(glue("Metabolic Scaling Exponent (b, entered):  ",
-                 {x$b}))
-  cat("\n")
-  cat(glue("Total Group Rate (tR, entered):           ",
-                 {x$tR}))
-  cat("\n")
-    cat("Masses (masses, entered): \n")
-    print(masses)
+  if(x$input == "manual"){
     cat("\n")
-
-    cat("Individual rates (indiv.rates, calculated): \n")
-    print(rates)
-
-    cat("\n")
-    cat(glue("Rate units: ", {x$units}))
-    cat("\n")
-    cat("\n")
+    cat("Total Group Rate(s) ($tR, entered):           \n")
+    print(x$tR)}
+  cat("\n")
+  cat("Metabolic Scaling Exponent ($b, entered):  \n")
+  print(x$b)
+  cat("\n")
+  cat("Masses ($masses, entered): \n")
+  print(masses)
+  cat("\n")
+  cat("Intercept(s) ($a, calculated) :               \n")
+  print(x$a)
+  cat("\n")
+  cat("Individual rates ($indiv.rates, calculated): \n")
+  print(rates)
+  cat(glue::glue("Rate units: ", {x$units}))
+  cat("\n")
+  cat("\n")
 }
 
 

--- a/R/scale_rate.R
+++ b/R/scale_rate.R
@@ -18,6 +18,14 @@
 #'   rates between -0.33 to 0. Therefore, make sure you use the correct scaling
 #'   exponent for the `rate` as entered, INCLUDING THE -/+ SIGN.
 #'
+#' @section Multiple rates: Multiple rates can be entered as a vector or as part
+#'   of a `respR::convert_rate` input. If `mass` is a single value, all rates
+#'   will be scaled to the `new.mass`. To scale multiple rates at different
+#'   masses (e.g. from different individuals), `rate` and `mass` should be of
+#'   equal length. The function is fully vectorised: all inputs accepts vectors,
+#'   but these should be single values or of the same length as `rate`. See
+#'   examples.
+#'
 #' @section `respR` integration: For the `rate` input the function accepts
 #'   objects saved (or piped) from the \code{respR}
 #'   (\url{https://github.com/januarharianto/respR}) `convert_rate` function. In
@@ -79,6 +87,17 @@
 #' ## mass-specific rate will be the same at any other body mass.
 #' scale_rate(4.77, mass = 2.5, new.mass = 18.3, b = 0)
 #'
+#' ## To scale multiple rates from the same individual, or multiple rates
+#' ## from different individuals of different mass, use vectors.
+#' # Individual with multiple rates
+#' scale_rate(c(1,2,3), mass = 2.5, new.mass = 10, b = 0.75)
+#' # Multiple individuals of different mass scaled to same `new.mass`
+#' scale_rate(c(1,2,3), mass = c(10,9,8), new.mass = 5, b = 0.75)
+#'
+#' ## You can fully vectorise all inputs, as long as they are single values
+#' ## or vectors of equal length (though not sure why you would want to...)
+#' scale_rate(c(1,2,3), mass = c(10,9,8), new.mass = c(5,6,7), b = c(0.7,0.8,0.9))
+#'
 #' @author Nicholas Carey - \email{nicholascarey@gmail.com}
 #'
 #' @export
@@ -101,7 +120,4 @@ scale_rate <- function(rate = NULL, mass = NULL, new.mass = NULL, b = NULL) {
   return(new.rate)
 }
 
-rate = 1
-mass = 2
-new.mass = 3
-b = 0.75
+

--- a/R/split_rate.R
+++ b/R/split_rate.R
@@ -2,20 +2,27 @@
 #'
 #' @description Divide a metabolic rate amongst a group of individuals.
 #'
-#' @details Divides a group metabolic rate amongst individuals, given body
-#'   masses of each and a scaling exponent.
+#' @details Divides a group metabolic rate amongst individuals in the group,
+#'   given body masses of each and a scaling exponent.
 #'
-#'   Take care to enter the correct scaling exponent (`b`). This is usually
-#'   (with exceptions) a positive value between 0.66 and 1. If your `b` value is
-#'   less than this, especially if it is less than 0.33, and *especially* if it
-#'   is negative, then it is likely a *mass-specific* scaling exponent. The
-#'   correct scaling exponent is the positive difference of this value from 1.
-#'   For example, for a scaling exponent of 0.75, the mass-specific scaling
-#'   exponent would be -0.25.
+#'   Take care to enter the correct scaling exponent (`b`). This should be the
+#'   scaling exponent of absolute metabolic rates, not mass-specific, and is
+#'   usually (with exceptions) a positive value between 0.66 and 1. If your `b`
+#'   value is less than this, especially if it is less than 0.33, and
+#'   *especially* if it is negative, then it is likely a *mass-specific* scaling
+#'   exponent. In which case, the correct scaling exponent is the positive
+#'   difference of this value from 1. For example, an absolute scaling exponent
+#'   of 0.75 has a mass-specific scaling exponent of -0.25.
 #'
 #'   If, for whatever reason, you want to do a simple per-capita division of the
 #'   rate regardless of the body masses, enter `b = 0`. Or just divide it by the
 #'   number of individuals.
+#'
+#'   Multiple rates can be entered, either as a vector or as part of a
+#'   `respR::convert_rate` input for `tR`, but these should be separate
+#'   measurements of rate of the same group. The output will contain separate
+#'   individual rate vectors for each group rate, and the intercept (`a`) for
+#'   each.
 #'
 #'   Units can be entered, e.g. `units = "mg/h"`, if the user wants to save
 #'   these in the output for reference, however they do not affect calculations
@@ -39,15 +46,15 @@
 #' @section `respR` integration: For total rate (`tR`) the function accepts
 #'   objects saved from the \code{respR}
 #'   (\url{https://github.com/januarharianto/respR}) `convert_rate` function. In
-#'   this case, the rate and units are automatically extracted. However, if it
-#'   contains a mass-specific rate (i.e. the rate has been adjusted in
-#'   `respR::convert_rate` to a specific mass), no conversion is done and a
+#'   this case, the rate(s) and units are automatically extracted. However, if
+#'   it contains a mass-specific rate (i.e. the rate has been adjusted in
+#'   `respR::convert_rate` to a specific mass), **no conversion is done** and a
 #'   warning is returned. Only absolute, that is non-mass specific, respiration
 #'   rates should be divided in this way.
 #'
-#' @section Output: Output is a \code{list} object containing 7 elements:
+#' @section Output: Output is a `list` object containing 7 elements:
 #'
-#'   `$a` = `a`, the intercept in the mass~rate power equation. Determined by
+#'   `$a` = `a`, the intercept(s) in the mass~rate power equation. Determined by
 #'   the function.
 #'
 #'   `$b` = `b`, the exponent in the mass~rate power equation. User entered.
@@ -59,23 +66,31 @@
 #'   `$units` = units of the rate. User entered or extracted from `convert_rate`
 #'   object. For information only, does not affect any calculations.
 #'
-#'   `$indiv.rates` = Primary output of interest. Group rate divided between
-#'   individuals. Sum should therefore equal tR. Determined by the function
+#'   `$indiv.rates` = Primary output of interest, the group rate divided between
+#'   individuals. This is a `list` object with each element a vector of
+#'   individual rates associated with the `tR` at the same position. The sum of
+#'   each vector should equal the associated `tR`. Extract via
+#'   `$indiv.rates[[1]]` etc.
 #'
 #'   `$input` = origin of `tR` and `units`. Either `manual` entry or
 #'   `convert_rate` object
 #'
 #' @usage split_rate(tR = NULL, masses, b = 0.75, units = NULL)
 #'
-#' @param tR numeric. Total group metabolic rate
-#' @param masses numeric. A vector of body masses of all individuals in group
-#' @param b numeric. Metabolic scaling exponent
-#' @param units string. Units of the rate. Extracted from `convert_rate` object or
-#'   can be entered by the user. For information only, does not affect any
+#' @param tR numeric. Total group metabolic rate. Single value or vector of
+#'   multiple measurements of rate of same group.
+#' @param masses numeric. A vector of body masses of all individuals in group.
+#' @param b numeric. Metabolic scaling exponent.
+#' @param units string. Units of the rate. Extracted from `convert_rate` object
+#'   or can be entered by the user. For information only, does not affect any
 #'   calculations.
 #'
 #' @examples
+#' # Single group rate
 #' split_rate(tR = 500, masses = c(2, 3, 4, 5, 6), b = 0.75)
+#'
+#' # Multiple group rate
+#' split_rate(tR = c(500,550,600), masses = c(2, 3, 4, 5, 6), b = 0.75)
 #'
 #' @author Nicholas Carey - \email{nicholascarey@gmail.com}
 #'
@@ -127,7 +142,7 @@ split_rate <- function(tR = NULL, masses, b = 0.75, units = NULL) {
 
     if(any(sapply(pattern, function(x) grepl(x, units))))
       stop("Mass-specific units detected in convert_rate object.
-  Cannot divide rate by mass if rate is already corrected for mass!")
+  Cannot split rate by mass if rate is already corrected for mass!")
   }
 
 
@@ -146,7 +161,8 @@ split_rate <- function(tR = NULL, masses, b = 0.75, units = NULL) {
   a <- rate / (sum(masses^b))
 
   ## return scaled rates
-  indiv_rates <- a * (masses^b)
+  ## lapply in case multiple rates
+  indiv_rates <- lapply(a, function(x) x * (masses^b))
 
   ## assemble output
   output <- list(

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,8 +42,7 @@ This function divides a metabolic rate between a group of individuals based on t
 *Benjamin P. Burford, Nicholas Carey, William F. Gilly, Jeremy A. Goldbogen. 2019. Grouping reduces the metabolic demand of a social squid. 
 **Marine Ecology Progress Series**. 612: 141–150 https://doi.org/10.3354/meps12880*
 
-This function integrates with the [`respR`](https://github.com/januarharianto/respR) package: objects saved from the `respR::convert_rate` function can be 
-entered (or `%>%` piped), and the rate and units will be automatically extracted. 
+Rates can be entered manually, and it also integrates with the [`respR`](https://github.com/januarharianto/respR) package: objects saved from the `respR::convert_rate` function can be entered (or `%>%` piped), and the rate and units will be automatically extracted. 
 
 ```{r echo = F}
 library(respfun)
@@ -55,7 +54,7 @@ library(respfun)
 split_rate(tR = 500,                  # total metabolic rate of group
            masses = c(2, 3, 4, 5, 6), # body masses
            b = 0.75,                  # metabolic scaling exponent
-           units = "mg/h")            # units
+           units = "mg/h")            # units (optional)
 ```
 
 ```{r eval = T, echo = F}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Goldbogen. 2019. Grouping reduces the metabolic demand of a social
 squid. **Marine Ecology Progress Series**. 612: 141–150
 <https://doi.org/10.3354/meps12880>*
 
-This function integrates with the
+Rates can be entered manually, and it also integrates with the
 [`respR`](https://github.com/januarharianto/respR) package: objects
 saved from the `respR::convert_rate` function can be entered (or `%>%`
 piped), and the rate and units will be automatically extracted.
@@ -64,20 +64,27 @@ piped), and the rate and units will be automatically extracted.
 split_rate(tR = 500,                  # total metabolic rate of group
            masses = c(2, 3, 4, 5, 6), # body masses
            b = 0.75,                  # metabolic scaling exponent
-           units = "mg/h")            # units
+           units = "mg/h")            # units (optional)
 ```
 
     #> 
     #> # split_rate # -------------------------
     #> Rate Division Complete: 
     #> 
-    #> Intercept (a, calculated) :               35.7984448854878
-    #> Metabolic Scaling Exponent (b, entered):  0.75
-    #> Total Group Rate (tR, entered):           500
-    #> Masses (masses, entered): 
+    #> Total Group Rate(s) ($tR, entered):           
+    #> [1] 500
+    #> 
+    #> Metabolic Scaling Exponent ($b, entered):  
+    #> [1] 0.75
+    #> 
+    #> Masses ($masses, entered): 
     #> [1] 2 3 4 5 6
     #> 
-    #> Individual rates (indiv.rates, calculated): 
+    #> Intercept(s) ($a, calculated) :               
+    #> [1] 35.79844
+    #> 
+    #> Individual rates ($indiv.rates, calculated): 
+    #> [[1]]
     #> [1]  60.20557  81.60281 101.25329 119.69931 137.23902
     #> 
     #> Rate units: mg/h
@@ -117,15 +124,21 @@ urchins.rd %>%                                           # NOT a group respirome
     #> Rate Division Complete: 
     #> --- respR::convert_rate object detected ---
     #> 
-    #> Intercept (a, calculated) :               -0.0618454810725696
-    #> Metabolic Scaling Exponent (b, entered):  0.75
-    #> Total Group Rate (tR, entered):           -1.42414265277951
-    #> Masses (masses, entered): 
+    #> Total Group Rate(s) ($tR, entered via convert_rate input):
+    #> [1] -1.424143
+    #> 
+    #> Metabolic Scaling Exponent ($b, entered):  
+    #> [1] 0.75
+    #> 
+    #> Masses ($masses, entered): 
     #> [1] 2 3 4 5 6 7 8
     #> 
-    #> Individual rates (indiv.rates, calculated): 
-    #> [1] -0.1040113 -0.1409772 -0.1749254 -0.2067928 -0.2370945 -0.2661531
-    #> [7] -0.2941883
+    #> Intercept(s) ($a, calculated) :               
+    #> [1] -0.06184548
+    #> 
+    #> Individual rates ($indiv.rates, calculated): 
+    #> [[1]]
+    #> [1] -0.1040113 -0.1409772 -0.1749254 -0.2067928 -0.2370945 -0.2661531 -0.2941883
     #> 
     #> Rate units: mg/hour
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,2 @@
 CHANGELOG
 
-v0.4.1
-
-- MAJOR FIX: incorrect results returned by `eff_vol`
-- FIX:`spec_density` : warning when wet_mass and buoy_mass are equal (leads to infinite density calculation)

--- a/man/scale_rate.Rd
+++ b/man/scale_rate.Rd
@@ -37,6 +37,16 @@ between +0.67 to +1 (i.e. between two-thirds and one), and mass-specific
 rates between -0.33 to 0. Therefore, make sure you use the correct scaling
 exponent for the \code{rate} as entered, INCLUDING THE -/+ SIGN.
 }
+\section{Multiple rates}{
+ Multiple rates can be entered as a vector or as part
+of a \code{respR::convert_rate} input. If \code{mass} is a single value, all rates
+will be scaled to the \code{new.mass}. To scale multiple rates at different
+masses (e.g. from different individuals), \code{rate} and \code{mass} should be of
+equal length. The function is fully vectorised: all inputs accepts vectors,
+but these should be single values or of the same length as \code{rate}. See
+examples.
+}
+
 \section{\code{respR} integration}{
  For the \code{rate} input the function accepts
 objects saved (or piped) from the \code{respR}
@@ -93,6 +103,17 @@ scale_rate(20, mass = 2, new.mass = 1, b = 1)
 ## is represented by a scaling exponent of zero. In this case the
 ## mass-specific rate will be the same at any other body mass.
 scale_rate(4.77, mass = 2.5, new.mass = 18.3, b = 0)
+
+## To scale multiple rates from the same individual, or multiple rates
+## from different individuals of different mass, use vectors.
+# Individual with multiple rates
+scale_rate(c(1,2,3), mass = 2.5, new.mass = 10, b = 0.75)
+# Multiple individuals of different mass scaled to same `new.mass`
+scale_rate(c(1,2,3), mass = c(10,9,8), new.mass = 5, b = 0.75)
+
+## You can fully vectorise all inputs, as long as they are single values
+## or vectors of equal length (though not sure why you would want to...)
+scale_rate(c(1,2,3), mass = c(10,9,8), new.mass = c(5,6,7), b = c(0.7,0.8,0.9))
 
 }
 \author{

--- a/man/split_rate.Rd
+++ b/man/split_rate.Rd
@@ -7,34 +7,42 @@
 split_rate(tR = NULL, masses, b = 0.75, units = NULL)
 }
 \arguments{
-\item{tR}{numeric. Total group metabolic rate}
+\item{tR}{numeric. Total group metabolic rate. Single value or vector of
+multiple measurements of rate of same group.}
 
-\item{masses}{numeric. A vector of body masses of all individuals in group}
+\item{masses}{numeric. A vector of body masses of all individuals in group.}
 
-\item{b}{numeric. Metabolic scaling exponent}
+\item{b}{numeric. Metabolic scaling exponent.}
 
-\item{units}{string. Units of the rate. Extracted from \code{convert_rate} object or
-can be entered by the user. For information only, does not affect any
+\item{units}{string. Units of the rate. Extracted from \code{convert_rate} object
+or can be entered by the user. For information only, does not affect any
 calculations.}
 }
 \description{
 Divide a metabolic rate amongst a group of individuals.
 }
 \details{
-Divides a group metabolic rate amongst individuals, given body
-masses of each and a scaling exponent.
+Divides a group metabolic rate amongst individuals in the group,
+given body masses of each and a scaling exponent.
 
-Take care to enter the correct scaling exponent (\code{b}). This is usually
-(with exceptions) a positive value between 0.66 and 1. If your \code{b} value is
-less than this, especially if it is less than 0.33, and \emph{especially} if it
-is negative, then it is likely a \emph{mass-specific} scaling exponent. The
-correct scaling exponent is the positive difference of this value from 1.
-For example, for a scaling exponent of 0.75, the mass-specific scaling
-exponent would be -0.25.
+Take care to enter the correct scaling exponent (\code{b}). This should be the
+scaling exponent of absolute metabolic rates, not mass-specific, and is
+usually (with exceptions) a positive value between 0.66 and 1. If your \code{b}
+value is less than this, especially if it is less than 0.33, and
+\emph{especially} if it is negative, then it is likely a \emph{mass-specific} scaling
+exponent. In which case, the correct scaling exponent is the positive
+difference of this value from 1. For example, an absolute scaling exponent
+of 0.75 has a mass-specific scaling exponent of -0.25.
 
 If, for whatever reason, you want to do a simple per-capita division of the
 rate regardless of the body masses, enter \code{b = 0}. Or just divide it by the
 number of individuals.
+
+Multiple rates can be entered, either as a vector or as part of a
+\code{respR::convert_rate} input for \code{tR}, but these should be separate
+measurements of rate of the same group. The output will contain separate
+individual rate vectors for each group rate, and the intercept (\code{a}) for
+each.
 
 Units can be entered, e.g. \code{units = "mg/h"}, if the user wants to save
 these in the output for reference, however they do not affect calculations
@@ -61,9 +69,9 @@ the signs for \code{a} and individual rates in the output.
  For total rate (\code{tR}) the function accepts
 objects saved from the \code{respR}
 (\url{https://github.com/januarharianto/respR}) \code{convert_rate} function. In
-this case, the rate and units are automatically extracted. However, if it
-contains a mass-specific rate (i.e. the rate has been adjusted in
-\code{respR::convert_rate} to a specific mass), no conversion is done and a
+this case, the rate(s) and units are automatically extracted. However, if
+it contains a mass-specific rate (i.e. the rate has been adjusted in
+\code{respR::convert_rate} to a specific mass), \strong{no conversion is done} and a
 warning is returned. Only absolute, that is non-mass specific, respiration
 rates should be divided in this way.
 }
@@ -71,7 +79,7 @@ rates should be divided in this way.
 \section{Output}{
  Output is a \code{list} object containing 7 elements:
 
-\verb{$a} = \code{a}, the intercept in the mass~rate power equation. Determined by
+\verb{$a} = \code{a}, the intercept(s) in the mass~rate power equation. Determined by
 the function.
 
 \verb{$b} = \code{b}, the exponent in the mass~rate power equation. User entered.
@@ -83,15 +91,22 @@ the function.
 \verb{$units} = units of the rate. User entered or extracted from \code{convert_rate}
 object. For information only, does not affect any calculations.
 
-\verb{$indiv.rates} = Primary output of interest. Group rate divided between
-individuals. Sum should therefore equal tR. Determined by the function
+\verb{$indiv.rates} = Primary output of interest, the group rate divided between
+individuals. This is a \code{list} object with each element a vector of
+individual rates associated with the \code{tR} at the same position. The sum of
+each vector should equal the associated \code{tR}. Extract via
+\verb{$indiv.rates[[1]]} etc.
 
 \verb{$input} = origin of \code{tR} and \code{units}. Either \code{manual} entry or
 \code{convert_rate} object
 }
 
 \examples{
+# Single group rate
 split_rate(tR = 500, masses = c(2, 3, 4, 5, 6), b = 0.75)
+
+# Multiple group rate
+split_rate(tR = c(500,550,600), masses = c(2, 3, 4, 5, 6), b = 0.75)
 
 }
 \author{

--- a/tests/testthat/test-split_rate.R
+++ b/tests/testthat/test-split_rate.R
@@ -102,10 +102,28 @@ expect_message(split_rate(masses = c(2, 3, 4, 5, 6, 7),
 
 # Test split rate totals group rate ---------------------------------------
 
-expect_equal(sum(respr_output_no_mass$indiv.rates),
+expect_equal(sum(respr_output_no_mass$indiv.rates[[1]]),
              respr_output_no_mass$tR)
 
-expect_equal(sum(simple_output$indiv.rates),
+expect_equal(sum(simple_output$indiv.rates[[1]]),
              simple_output$tR)
 
 
+# Test works with multiple rates ------------------------------------------
+
+
+mult_output <- split_rate(masses = c(2, 3, 4, 5, 6, 7),
+                            tR = c(500,600,700),
+                            b = 0.75)
+
+expect_equal(sum(mult_output$indiv.rates[[1]]),
+             mult_output$tR[1])
+
+expect_equal(sum(mult_output$indiv.rates[[2]]),
+             mult_output$tR[2])
+
+expect_equal(length(mult_output$indiv.rates),
+             length(mult_output$tR))
+
+expect_equal(length(mult_output$indiv.rates),
+             length(mult_output$a))


### PR DESCRIPTION
Minor update

- `split_rate` now accepts multiple input rates, including from `convert_rate` objects. These should obviously all be rates from the *same group*. Minor change to output object as a result: `$indiv.rates` is now a `list` object with each element a vector of individual rates for teh associated group rate in `tR`. Extract via ``$indiv.rates[[1]]` etc.